### PR TITLE
added hosts list functionality

### DIFF
--- a/.testdata/hosts.list
+++ b/.testdata/hosts.list
@@ -1,0 +1,8 @@
+# This is a comment
+! This is a comment
+; This is a comment
+
+0.0.0.0 example.com
+0.0.0.0 	example.net
+0.0.0.0 		example.com
+0.0.0.0 noop example.com

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The *filter* plugin is used to block domain name resolution, simliar to
 ```nginx
 filter {
     ACTION TYPE DATA
-    ACTION list TYPE DATA
 }
 ```
 
@@ -29,8 +28,23 @@ filter {
     * Adblock Plus: `||example.com^`
     * DNSMasq Address: `address=/example.com/#`
 
-If the **ACTION** is a `list`, then **DATA** is a `[ file | http | https ]` URL.
-Lists must contain only the **TYPE** specified.
+```nginx
+filter {
+    ACTION list TYPE DATA
+}
+```
+
+* **ACTION**: `[ allow | block ]` What action to take
+* **DATA**: Lists of the following data types
+  * `domain`: A raw domain to match. Subdomains are not matched
+  * `hosts`: A hostsfile formatted list
+  * `regex`: A Go-formatted Regular Expression
+  * `wildcard`: Common wildcard formats
+    * Generic: `*.example.com`
+    * Adblock Plus: `||example.com^`
+    * DNSMasq Address: `address=/example.com/#`
+* **DATA**: A `[ file | http | https ]` URL. Must contain only the **TYPE**
+specified.
 
 ```nginx
 filter {
@@ -88,7 +102,7 @@ filter {
 
 This flexibility is extended to wildcard lists as well. AdblockPlus and DNSMasq
 formats are supported for flexibility and ease of migration from other
-solutions. Hosts, zone, and Unbound configuration files are not supported.
+solutions. Zone and Unbound configuration files are not supported.
 
 ## Examples
 

--- a/action_test.go
+++ b/action_test.go
@@ -9,6 +9,7 @@ func TestActionList404(t *testing.T) {
 		block list domain https://httpbin.org/status/404
 		block list regex https://httpbin.org/status/404
 		block list wildcard https://httpbin.org/noop
+		block list hosts https://httpbin.org/status/404
 	}`
 	filter := NewTestFilter(t, corefile)
 	filter.Build()
@@ -35,6 +36,20 @@ func TestActionListDomain(t *testing.T) {
 	// 		filter.blockTree.Len(),
 	// 	)
 	// }
+	if len(filter.blockDomains) != 2 {
+		t.Errorf(
+			"expected two domains; found %d",
+			len(filter.blockDomains),
+		)
+	}
+}
+
+func TestActionListHosts(t *testing.T) {
+	corefile := `filter {
+		block list hosts file://.testdata/hosts.list
+	}`
+	filter := NewTestFilter(t, corefile)
+	filter.Build()
 	if len(filter.blockDomains) != 2 {
 		t.Errorf(
 			"expected two domains; found %d",

--- a/setup.go
+++ b/setup.go
@@ -172,6 +172,10 @@ func parseActionList(c *caddy.Controller, f *Filter, a ActionType) error {
 		if err := parseActionListDomain(c, f, a); err != nil {
 			return err
 		}
+	case "hosts":
+		if err := parseActionListHosts(c, f, a); err != nil {
+			return err
+		}
 	case "regex":
 		if err := parseActionListRegex(c, f, a); err != nil {
 			return err
@@ -202,6 +206,23 @@ func parseActionListDomain(c *caddy.Controller, f *Filter, a ActionType) error {
 		}
 	case ActionTypeBlock:
 		if err := f.blockConfig.AddDomainList(c.Val()); err != nil {
+			return err
+		}
+	}
+	return ensureEOL(c)
+}
+
+func parseActionListHosts(c *caddy.Controller, f *Filter, a ActionType) error {
+	if !c.NextArg() {
+		return c.Errf("no %s hosts list specified", a)
+	}
+	switch a {
+	case ActionTypeAllow:
+		if err := f.allowConfig.AddHostsList(c.Val()); err != nil {
+			return err
+		}
+	case ActionTypeBlock:
+		if err := f.blockConfig.AddHostsList(c.Val()); err != nil {
 			return err
 		}
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -352,6 +352,35 @@ func TestAllowList(t *testing.T) {
 			false,
 		},
 		{
+			"allow list hosts no url",
+			`filter {
+				allow list hosts
+			}`,
+			true,
+		},
+		{
+			"allow list hosts invalid url",
+			`filter {
+				allow list hosts "file://invalid url"
+			}`,
+			true,
+		},
+		{
+			"allow list hosts from file",
+			`filter {
+				allow list hosts file://.testdata/hosts.list
+			}`,
+			false,
+		},
+		{
+			"allow list hosts duplicate",
+			`filter {
+				allow list hosts file://.testdata/hosts.list
+				allow list hosts file://.testdata/hosts.list
+			}`,
+			false,
+		},
+		{
 			"allow list regex no url",
 			`filter {
 				allow list regex
@@ -497,6 +526,35 @@ func TestBlockList(t *testing.T) {
 			"block list domain https",
 			`filter {
 				block list domain https://dbl.oisd.nl/basic/
+			}`,
+			false,
+		},
+		{
+			"block list hosts no url",
+			`filter {
+				block list hosts
+			}`,
+			true,
+		},
+		{
+			"block list hosts invalid url",
+			`filter {
+				block list hosts "file://invalid url"
+			}`,
+			true,
+		},
+		{
+			"block list hosts from file",
+			`filter {
+				block list hosts file://.testdata/hosts.list
+			}`,
+			false,
+		},
+		{
+			"block list hosts duplicate",
+			`filter {
+				block list hosts file://.testdata/hosts.list
+				block list hosts file://.testdata/hosts.list
 			}`,
 			false,
 		},


### PR DESCRIPTION
<!-- If your pull request contains multiple commits, be sure to squash them. -->

## Changes

Added list type `hosts` to load files using hosts file format.

```sh
# ./hosts
0.0.0.0 example.com
0.0.0.0 example.net
```

```nginx
# Corefile
filter {
    block list hosts file://hosts
}
```

## Justification

Expands the types of lists usable. Eases the transition from other DNS Sinkhole solutions since many popular lists use the hosts format.

