### PR TITLE
added listresolver directive

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,11 @@
             "label": "Go Coverage",
             "type": "shell",
             "command": "go test -coverprofile='coverage.out'",
+            "options": {
+                "env": {
+                    "CGO_ENABLED": "0"
+                }
+            },
             "problemMatcher": {
                 "pattern": {
                     "regexp": ".*"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ filter {
 * **DURATION** (DEFAULT=`24h`): any value accepted by
 [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)
 
+```nginx
+filter {
+    listresolver [ RESOLVER ]
+}
+```
+
+* **RESOLVER**: a resolver IP address to use when fetching remote lists. `dns`
+and `tls` schemes are accepted. Ports may be specified. IPv6 address are
+accepted when used with a scheme and port. Since `listresolver` is intended to
+be used when no other resolvers are available, only IP addresses are accepted.
+
 ## Domain Matching
 
 | Directive                         | Description
@@ -109,10 +120,12 @@ solutions. Zone and Unbound configuration files are not supported.
 
 ```nginx
 # Use an aggregated block list, but allow `vortex.data.microsoft.com` for XBox
-# Live achievements. Respond to blocked domains with `A 0.0.0.0` and `AAAA ::`
-# records. Update list every 24 hours.
+# Live achievements. Retrieve the block list using Quad9 over TLS. Respond to
+# blocked domains with `A 0.0.0.0` and `AAAA ::` records. Update list every 24
+# hours.
 
 filter {
+    listresolver tls://9.9.9.9
     block list domain https://dbl.oisd.nl/basic/
     allow domain vortex.data.microsoft.com
 }

--- a/action_test.go
+++ b/action_test.go
@@ -154,3 +154,15 @@ func TestActionWildcardDNSMasq(t *testing.T) {
 	filter := NewTestFilter(t, corefile)
 	filter.Build()
 }
+
+func TestListResolver(t *testing.T) {
+	corefile := `filter {
+		listresolver 9.9.9.9
+		block list domain https://dbl.oisd.nl/basic/
+	}`
+	filter := NewTestFilter(t, corefile)
+	filter.Build()
+	if len(filter.blockDomains) == 0 {
+		t.Errorf("expected no domains; got %d", len(filter.blockDomains))
+	}
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -917,3 +917,66 @@ func TestParserEOLErrorText(t *testing.T) {
 		t.Errorf("unexpected error text `%s`; expected `%s`", err, expected)
 	}
 }
+
+func TestParserListResolver(t *testing.T) {
+	tests := []testSetup{
+		{
+			"listresolver none specified",
+			`filter {
+				listresolver
+			}`,
+			true,
+		},
+		{
+			"listresolver nonsensical",
+			`filter {
+				listresolver noop
+			}`,
+			true,
+		},
+		{
+			"listresolver ip colon no port",
+			`filter {
+				listresolver 9.9.9.9:
+			}`,
+			true,
+		},
+		{
+			"listresolver quad9 default",
+			`filter {
+				listresolver 9.9.9.9
+			}`,
+			false,
+		},
+		{
+			"listresolver quad9 dns",
+			`filter {
+				listresolver dns://9.9.9.9
+			}`,
+			false,
+		},
+		{
+			"listresolver quad9 tls",
+			`filter {
+				listresolver tls://9.9.9.9
+			}`,
+			false,
+		},
+		{
+			"listresolver quad9 unsupported transport",
+			`filter {
+				listresolver https://9.9.9.9
+			}`,
+			true,
+		},
+		{
+			"listresolver quad9 domain name",
+			`filter {
+				listresolver tls://dns.quad9.net
+			}`,
+			true,
+		},
+	}
+
+	RunSetupTests(t, tests)
+}


### PR DESCRIPTION
## Changes

added listresolver directive to configuration

```nginx
filter {
    listresolver tls://9.9.9.9
    block list domain https://example.com/list.txt
}
```

Resolvers can be specified identically to how the `forward` plugin is configured.

```nginx
filter {
    listresolver 9.9.9.9
    listresolver 9.9.9.9:53
    listresolver dns://9.9.9.9
    listresolver tls://9.9.9.9
    listresolver [2620:fe::fe]:53
    listresolver dns://[2620:fe::fe]:53
    listresolver tls://[2620:fe::fe]:853
}
```

To implement this feature, the following changes were made:
- `ListLoadFunc` was changed to a `ListLoader` interface using a `Load` function to execute GET requests
- Separate loaders (`file`, `http/s`) were given individual fields in the `ActionConfig` object to be accessible during list building instead of using standalone package-scoped functions. (I don't feel like this is the best solution, but for now it works as intended)


## Justification

If CoreDNS is the sole resolver and the system it's running on is not configured to use an upstream resolver, remote lists will fail to load since the domains cannot be resolved. Using the `forward` or `unbound` plugins will not work since they are not actively resolving until after setup.

This gets around this limitation by creating an `http.Client` configured to use only the specified resolver to fetch lists.

Potentially, this may be a non-issue if using a low `update` duration as CoreDNS would be resolving during that process, but this is untested.
