### PR TITLE
fix: listresolver tls client now actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ filter {
 
 ```nginx
 filter {
-    listresolver [ RESOLVER ]
+    listresolver RESOLVER [ SERVER_NAME ]
 }
 ```
 
@@ -82,6 +82,9 @@ filter {
 and `tls` schemes are accepted. Ports may be specified. IPv6 address are
 accepted when used with a scheme and port. Since `listresolver` is intended to
 be used when no other resolvers are available, only IP addresses are accepted.
+* **SERVER_NAME**: Only used when resolver scheme is `tls`. Must be the host
+name of the resolver, otherwise resolving will fail due to being unable to
+verify the resolver's certificate.
 
 ## Domain Matching
 
@@ -125,7 +128,7 @@ solutions. Zone and Unbound configuration files are not supported.
 # hours.
 
 filter {
-    listresolver tls://9.9.9.9
+    listresolver tls://9.9.9.9 dns.quad9.net
     block list domain https://dbl.oisd.nl/basic/
     allow domain vortex.data.microsoft.com
 }

--- a/action_test.go
+++ b/action_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -156,6 +157,7 @@ func TestActionWildcardDNSMasq(t *testing.T) {
 }
 
 func TestListResolver(t *testing.T) {
+	http.DefaultTransport = nil
 	corefile := `filter {
 		listresolver 9.9.9.9
 		block list domain https://dbl.oisd.nl/basic/
@@ -163,6 +165,19 @@ func TestListResolver(t *testing.T) {
 	filter := NewTestFilter(t, corefile)
 	filter.Build()
 	if len(filter.blockDomains) == 0 {
-		t.Errorf("expected no domains; got %d", len(filter.blockDomains))
+		t.Error("expected domains; got none")
+	}
+}
+
+func TestListResolverTLS(t *testing.T) {
+	http.DefaultTransport = nil
+	corefile := `filter {
+		listresolver tls://9.9.9.9 dns.quad9.net
+		block list domain https://dbl.oisd.nl/basic/
+	}`
+	filter := NewTestFilter(t, corefile)
+	filter.Build()
+	if len(filter.blockDomains) == 0 {
+		t.Errorf("expected domains; got none")
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -956,9 +956,16 @@ func TestParserListResolver(t *testing.T) {
 			false,
 		},
 		{
-			"listresolver quad9 tls",
+			"listresolver quad9 tls without server name",
 			`filter {
 				listresolver tls://9.9.9.9
+			}`,
+			true,
+		},
+		{
+			"listresolver quad9 tls without server name",
+			`filter {
+				listresolver tls://9.9.9.9 dns.quad9.net
 			}`,
 			false,
 		},


### PR DESCRIPTION
## Changes

- listresolver directive consumes server name when using the tls scheme
- added test for tls server name
- listresolver tests now should not fall back to the system resolver

```diff
 filter {
     listresolver 9.9.9.9
     listresolver dns://9.9.9.9
-    listresolver tls://9.9.9.9
+    listresolver tls://9.9.9.9 dns.quad9.net
 }
```

## Justification

The initial version of the `listresolver` directive for some reason never actually created a TLS client for making request to DNS-over-TLS servers.

It does that now.

Closes #3 