### PR TITLE
emt: added os-specific commands for code analysis task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,8 +40,13 @@
         {
             "label": "Run Sonar-Scanner",
             "type": "shell",
-            "command": [
-                "sonar-scanner.bat",
+            "linux":{
+                "command": "~/Downloads/sonar-scanner/bin/sonar-scanner"
+            },
+            "windows": {
+                "command": "sonar-scanner.bat"
+            },
+            "args": [
                 "-D'sonar.projectKey=coredns-filter'",
                 "-D'sonar.sources=.'",
                 "-D'sonar.exclusions=**/*_test.go,.testdata/*'",
@@ -64,7 +69,6 @@
             "type": "promptString",
             "id": "sonarqubeUrl",
             "description": "SonarQube URL",
-            "default": "http://wsl.local:9000"
         },
         {
             "type": "promptString",


### PR DESCRIPTION
## Changes

- VSCode task for running Sonar Scanner now has different command binary commands for Windows and Linux
- Default task input for Sonar URL removed

## Justification

Previous Sonar Scanner task was configured to only run on Windows. Now, the `sonar-scanner` runs on both Windows and Linux.
