### PR TITLE
[MAINT]: added containerfile arguments for go and coredns version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 --branch ${COREDNS_VERSION} \
 
 WORKDIR /coredns/
 
-RUN go get -u github.com/wranders/coredns-filter
+RUN go get github.com/wranders/coredns-filter
 
 RUN sed -i '/^cache:cache/i filter:github.com/wranders/coredns-filter' plugin.cfg
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,19 @@
+# Go version used by Coredns
+ARG GO_VERSION=1.20.10
+# Coredns version used by coredns-filter
+ARG COREDNS_VERSION=v1.10.0
+
 FROM --platform=$BUILDPLATFORM registry.fedoraproject.org/fedora:37 as BUILDER
 RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
     ca-certificates git make
-ARG BUILDARCH
-RUN curl -L https://go.dev/dl/go1.20.1.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -zx
+ARG BUILDARCH GO_VERSION
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz | \
+    tar -C /usr/local -zx
 ENV PATH /usr/local/go/bin:$PATH
 
-RUN git clone https://github.com/coredns/coredns.git /coredns
+ARG COREDNS_VERSION
+RUN git clone --depth 1 --branch ${COREDNS_VERSION} \
+    https://github.com/coredns/coredns.git /coredns
 WORKDIR /coredns/
 RUN go get -u github.com/wranders/coredns-filter
 RUN sed -i '/^cache:cache/i filter:github.com/wranders/coredns-filter' plugin.cfg

--- a/Containerfile
+++ b/Containerfile
@@ -3,9 +3,13 @@ ARG GO_VERSION=1.20.10
 # Coredns version used by coredns-filter
 ARG COREDNS_VERSION=v1.10.0
 
+#===============================================================================
+
 FROM --platform=$BUILDPLATFORM registry.fedoraproject.org/fedora:37 as BUILDER
+
 RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
     ca-certificates git make
+
 ARG BUILDARCH GO_VERSION
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz | \
     tar -C /usr/local -zx
@@ -14,11 +18,14 @@ ENV PATH /usr/local/go/bin:$PATH
 ARG COREDNS_VERSION
 RUN git clone --depth 1 --branch ${COREDNS_VERSION} \
     https://github.com/coredns/coredns.git /coredns
+
 WORKDIR /coredns/
+
 RUN go get -u github.com/wranders/coredns-filter
+
 RUN sed -i '/^cache:cache/i filter:github.com/wranders/coredns-filter' plugin.cfg
-ARG TARGETOS
-ARG TARGETARCH
+
+ARG TARGETOS TARGETARCH
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make
 
 RUN useradd coredns --no-log-init -U -M -s /sbin/nologin
@@ -30,17 +37,27 @@ RUN mkdir user && \
     chown root:root user/{group,passwd} && \
     chmod 0644 user/{group,passwd}
 
+#===============================================================================
+
 FROM --platform=$TARGETPLATFORM scratch
+
 LABEL org.opencontainers.image.source="https://github.com/wranders/coredns-filter" \
     org.opencontainers.image.authors="W Anders <w@doubleu.codes>" \
     org.opencontainers.image.title="coredns-filter" \
     org.opencontainers.image.description="Sinkholing in CoreDNS" \
     org.opencontainers.image.licenses="MIT"
+
 COPY --from=BUILDER /coredns/coredns /
+
 COPY --from=BUILDER /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
     /etc/ssl/certs/ca-certificates.crt
+
 COPY --from=BUILDER /sbin/nologin /sbin/
+
 COPY --from=BUILDER /coredns/user/group /coredns/user/passwd /etc/
+
 EXPOSE 53/udp 443 853
+
 USER coredns
+
 ENTRYPOINT [ "/coredns" ]

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Go version used by Coredns
-ARG GO_VERSION=1.20.10
+ARG GO_VERSION=1.19.13
 # Coredns version used by coredns-filter
 ARG COREDNS_VERSION=v1.10.0
 


### PR DESCRIPTION
## Changes

- added containerfile arguments for go and coredns versions
- changed containerfile formatting to improve readability
- changed go get command to remove updating from plugin

## Justification

Go version is specified to correspond to the version used by CoreDNS or the Go version used by this plugin, whichever is greater. Sourced from the latest minor version from CoreDNS's [go.mod](https://github.com/coredns/coredns/blob/master/go.mod) or the plugin's `go.mod`.

CoreDNS version is specified to correspond to the version of Go used by the version of CoreDNS used in this plugin.