### PR TITLE
[MAINT]: changed coverage workflow to only run when plugin source files are mo…

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,10 @@ on:
     - feat-*
     - update-*
   pull_request:
+    paths:
+    - '**.go'
+    - go.mod
+    - go.sum
     types:
     - opened
     - synchronize


### PR DESCRIPTION
## Changes

- changed coverage workflow to only run when plugin source files are changed

## Justification

This will prevent coverage tests from running when plugin sources files are not modified.

Closes #14 
