### PR TITLE
[MAINT]: added fetch depth to checkout action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 1
         fetch-tags: true
     - run: git tag -l --format='%(contents:subject)%0a%0a%(contents:body)' > RELEASE.txt
     - uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Changes

- added fetch-depth attribute to checkout action

## Justification

There appears to be a bug in [actions/checkout](https://github.com/actions/checkout) where a workflow triggered by a tag cannot actually fetch the tags. actions/checkout#1467
