### PR TITLE
Maint release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-        fetch-tags: true
     - run: git tag -l --format='%(contents:subject)%0a%0a%(contents:body)' > RELEASE.txt
     - uses: softprops/action-gh-release@v1
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 1
         fetch-tags: true
     - run: git tag -l --format='%(contents:subject)%0a%0a%(contents:body)' > RELEASE.txt
     - uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Changes

- removed arguments from release workflow checkout action

## Justification

It seems that specifying the `fetch-depth` while also specifying `fetch-tags` in a workflow that is triggered by a tag results in failure. This was the second solution mentioned in actions/checkout#1467.
