### PR TITLE
fix(ci): use correct digest value for provenance attestation

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -138,7 +138,7 @@ jobs:
         id: attest-ghcr
         with:
           subject-name: ${{ steps.images.outputs.ghcr }}
-          subject-digest: ${{ steps.images.outputs.ghcr_digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
 
       #=========================================================================
       - name: Attach GHCR Provenance
@@ -182,7 +182,7 @@ jobs:
         id: attest-quay
         with:
           subject-name: ${{ steps.images.outputs.quay }}
-          subject-digest: ${{ steps.images.outputs.quay_digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
 
       #=========================================================================
       - name: Attach Quay Provenance


### PR DESCRIPTION
<!-- If your pull request contains multiple commits, be sure to squash them. -->

## Changes

- fix incorrect digest value use in provenance attestation step

## Justification

Provenance attestation Action was previously being provided the incorrect step digest value.
