### PR TITLE
fix(ci): fix cosign command

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -148,7 +148,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cosign login ghcr.io -u "${{ github.actor }}" -p "$GH_TOKEN"
-          cosign attach-signature \
+          cosign attach attestation \
             --attestation="${{ steps.attest-ghcr.outputs.bundle-path }}" \
             "${{ steps.images.outputs.ghcr_digest }}"
 
@@ -193,7 +193,7 @@ jobs:
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
           cosign login quay.io -u "$QUAY_USERNAME" -p "$QUAY_TOKEN"
-          cosign attach-signature \
+          cosign attach attestation \
             --attestation="${{ steps.attest-quay.outputs.bundle-path }}" \
             "${{ steps.images.outputs.quay_digest }}"
 


### PR DESCRIPTION
## Changes

- fix cosign command that attaches the provenance attestation

## Justification

The command used in the step to attach the provenance attestation was incorrect, likely an error by IDE autocorrect.
