### PR TITLE
fix(ci): fix quay credential variables

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -322,7 +322,7 @@ jobs:
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
           cosign login ghcr.io -u "$GHCR_USERNAME" -p "$GHCR_TOKEN"
-          cosign login quay.io -u "$QUAY_USER" -p "$QUAY_TOKEN"
+          cosign login quay.io -u "$QUAY_USERNAME" -p "$QUAY_TOKEN"
           images=""
           for image in $(tr '\n' ' ' <<< '${{ steps.meta.outputs.tags }}'); do
             images+="$(skopeo inspect --format='{{.Name}}@{{.Digest}}' docker://$image) "


### PR DESCRIPTION
## Changes

- fix quay credential variable in manifest signing step

## Justification

Final manifest signing step was using incorrect Quay username credential, resulting on Action failure.
