### PR TITLE
fix: coverage workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -24,10 +24,10 @@ jobs:
   build-test-publish_coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: stable
     - run: go build

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,7 +32,7 @@ jobs:
         go-version: stable
     - run: go build
     - run: go test -coverprofile='coverage.out'
-    - uses: sonarsource/sonarqube-scan-action@v4
+    - uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 #v7.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Changes

- update sonarqube/scan-action
- update action versions

## Justification

The version of the action used in the SonarQube scanning step was vulnerable to CVE-2025-58178. Updated the `checkout` and `setup-go` actions as well since they used deprecated `node` versions.