### PR TITLE
build: add container targetarch parsing to go installation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,9 +9,12 @@ RUN dnf install -y --setopt=install_weak_deps=False --no-docs \
     make \
     util-linux
 
+ARG TARGETARCH
 RUN { \
       GO_VERSION=$(curl -s 'https://go.dev/VERSION?m=text' | sed -ne 's/^go//p'); \
-      curl -# -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
+      GO_ARCH=$TARGETARCH; \
+      if [[ "$TARGETARCH" == "arm" ]]; then GO_ARCH="arm64"; fi; \
+      curl -# -L https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz | \
         tar -C /usr/local -zx; \
     }
 ENV PATH=/usr/local/go/bin:$PATH


### PR DESCRIPTION
## Changes

- add container targetarch parsing for go installation

## Justification

Previous version incorrectly hard-coded `amd64` architecture for Go installation, even when run on ARM runners, resulting in build errors.
