### PR TITLE
build: replace container targetarch with buildarch

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,7 +30,11 @@ RUN go get github.com/wranders/coredns-filter
 
 RUN sed -i '/^cache:cache/i filter:github.com/wranders/coredns-filter' plugin.cfg
 
-RUN make
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN export GOARCH=$TARGETARCH; \
+    export GOARM=$(echo "$TARGETVARIANT" | sed -ne 's/^v//p'); \
+    make
 
 RUN mkdir -p /scratch/etc/ && \
     touch /scratch/etc/{passwd,group} && \

--- a/Containerfile
+++ b/Containerfile
@@ -9,11 +9,11 @@ RUN dnf install -y --setopt=install_weak_deps=False --no-docs \
     make \
     util-linux
 
-ARG TARGETARCH
+ARG BUILDARCH
 RUN { \
       GO_VERSION=$(curl -s 'https://go.dev/VERSION?m=text' | sed -ne 's/^go//p'); \
-      GO_ARCH=$TARGETARCH; \
-      if [[ "$TARGETARCH" == "arm" ]]; then GO_ARCH="arm64"; fi; \
+      GO_ARCH=$BUILDARCH; \
+      if [[ "$BUILDARCH" == "arm" ]]; then GO_ARCH="arm64"; fi; \
       curl -# -L https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz | \
         tar -C /usr/local -zx; \
     }


### PR DESCRIPTION
## Changes

- replace container targetarch with buildarch
- add container targetarch and targetvariant to make step

## Justification

Messed that one up. Go install should be the runner's arch.

`TARGETARCH` and `TARGETVARIANT` are passed to `make` so that the correct arch format is built.
