### PR TITLE
Fix error when loading absolute file URLs

### DIFF
--- a/load.go
+++ b/load.go
@@ -27,16 +27,22 @@ func (a ActionConfig) GetListLoader(uri string) (ListLoader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid list URL %q; %w", uri, err)
 	}
-	if len(listUrl.Scheme) == 0 || len(listUrl.Host) == 0 {
-		// URL parsing ambiguity means Parse does not always return an error
-		// with an invalid URL. Explicitly check that the Scheme and Host are
-		// non-zero values so that they will be usable later.
-		return nil, fmt.Errorf("invalid list URL %q; scheme or host empty", uri)
+
+	// url.Parse does not require that the URL has a schema. Explicitly check
+	// for a scheme so that we know which loader to use.
+	if len(listUrl.Scheme) == 0 {
+		return nil, fmt.Errorf("invalid list URL %q; scheme empty", uri)
 	}
+
 	switch listUrl.Scheme {
 	case "file":
 		return a.FileLoader, nil
 	case "http", "https":
+		// url.Parse does not require that the URL has a host. Explicitly check
+		// for a host for network schemes only.
+		if len(listUrl.Host) == 0 {
+			return nil, fmt.Errorf("invalid list URL %q; host empty", uri)
+		}
 		return a.HTTPLoader, nil
 	default:
 		return nil, fmt.Errorf(

--- a/load_test.go
+++ b/load_test.go
@@ -2,6 +2,9 @@ package filter
 
 import (
 	"net/http"
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -36,7 +39,22 @@ func TestLoadNonExistant(t *testing.T) {
 		true,
 	}
 	RunFilterBuildTest(t, test)
+}
 
+func TestLoadAbsoluteFile(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("error getting working directory: %v", err)
+	}
+
+	test := TestFilterBuild{
+		"check absolute file path",
+		`filter {
+				allow list domain file://` + path.Join(filepath.ToSlash(cwd), ".testdata/empty.list") + `
+			}`,
+		true,
+	}
+	RunFilterBuildTest(t, test)
 }
 
 func TestLoadNonExistantExternal(t *testing.T) {


### PR DESCRIPTION
## Changes

Relative file URLs (with at least two segments) parse the first segment as the "host", passing the check that required both a scheme and a host. But absolute file URLs and relative URLs with a single segment have an empty host and fail validation.

Split the URL check in to two parts: always check for a scheme, but only check for a host for network schemes (`http` and `https`). Add a new test that uses an absolute path to verify this works. The test uses an empty file to avoid testing specific parsing logic at the same time.

## Justification

Absolute file URLs are useful to specify lists without depending on the directory where CoreDNS happens to be running. The README also includes an example using an absolute file URL.