### PR TITLE
fix: retract erroneous tags

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,7 +32,7 @@ jobs:
         go-version: stable
     - run: go build
     - run: go test -coverprofile='coverage.out'
-    - uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 #v7.0.0
+    - uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e #v8.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -43,3 +43,8 @@ require (
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+retract (
+	v0.4.1	// original published accidentally
+	v0.4.2  // published accidentally
+)


### PR DESCRIPTION
## Changes

- fix: retract erroneous tags
- chore(ci): update coverage action version

## Justification

Fixes #47. Tags `v0.4.1` and `v0.4.2` were originally pushed on accident while working on local Actions updates, resulting in the Go Proxy Cache serving those versions instead of newer commits tagged with those versions. This change retracts those versions so Go tooling will not use them.